### PR TITLE
Added devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "image": "docker.io/node:22-alpine",
+  "mounts": [
+    "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/root/.ssh"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+      ]
+    }
+  },
+  "features": {
+    "ghcr.io/cirolosapio/devcontainers-features/alpine-openssh:0": {},
+    "ghcr.io/cirolosapio/devcontainers-features/alpine-git:0": {}
+  },
+  "forwardPorts": [3000],
+  "shutdownAction": "stopContainer",
+  "containerEnv": {
+    "NODE_ENV": "development"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ no-as-service/
 ├── index.js            # Express API
 ├── reasons.json        # 1000+ universal rejection reasons
 ├── package.json
+├── .devcontainer.json  # VS Code / Github devcontainer setup
 └── README.md
 ```
 
@@ -117,6 +118,10 @@ For reference, here’s the package config:
 ```
 
 ---
+
+## ⚓ Devcontainer
+
+If you open this repo in Github Codespaces, it will automatically use `.devcontainer.json` to set up your environment.  If you open it in VSCode, it will ask you if you want to reopen it in a container.
 
 ## 👤 Author
 


### PR DESCRIPTION
This PR adds a development container (distinct - but similarly configured - from @croadfeldt's deployment container setup in #20), which ensures a consistent development experience for contributors.