### PR TITLE
feat: add Raycast extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Here are some projects and websites that creatively integrate [no-as-a-service](
 5. **[NoAsAnApp](https://github.com/omar-jarid/NoAsAnApp)**  
    A simple native Android app calling no-as-a-service to provide negative responses.
 
-6. **[No as a Service - Raycast Extension](https://github.com/matholamew/no-as-a-service/)**  
+6. **[No as a Service - Raycast Extension](https://www.raycast.com/nedini/no-as-a-service)**  
    Get a random No from within Raycast. Just install the extension from the Raycast store, open Raycast, then type in 'Random No'. Raycast extension: [No as a Service](https://www.raycast.com/nedini/no-as-a-service).
 
 7. **[Your Project Here?](https://github.com/YOUR_REPO)**  


### PR DESCRIPTION
## Description
I've created and published an official Raycast extension for **No-as-a-Service**. This allows Raycast users to generate and copy rejection reasons directly from their command palette.

The extension is now live on the Raycast Store:
[https://www.raycast.com/nedini/no-as-a-service](https://www.raycast.com/nedini/no-as-a-service)
[![Raycast Extension](https://img.shields.io/badge/Raycast-Extension-red?logo=raycast)](https://www.raycast.com/matholamew/no-as-a-service)

## Changes
- Added a link to the Raycast extension in the README.

Thanks for the great API!