### PR TITLE
Add Nope Chrome Extension to featured projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ Here are some projects and websites that creatively integrate [no-as-a-service](
 15. **[No MCP](https://github.com/clafoutis42/no-mcp)**  
     Perfect for when you want your AI to be consistently negative or just want to add some humor to your MCP setup.
 
-16. **[Your Project Here?](https://github.com/YOUR_REPO)**
+16. **[Nope - Chrome Extension](https://github.com/xedgecoder/nope-extension)**
+   A Chrome extension that fetches a random excuse on every click and auto-copies it to your clipboard. Built with vanilla JS, no dependencies.
+
+17. **[Your Project Here?](https://github.com/YOUR_REPO)**
    If you're using no-as-a-service in your project, open a pull request to be featured here!
 
 ---


### PR DESCRIPTION
## Summary

- Adds [Nope](https://github.com/xedgecoder/nope-extension), a Chrome extension that uses no-as-a-service to generate random excuses
- Fetches a new excuse on every click and auto-copies it to the clipboard
- Built with vanilla JS, zero dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)