### PR TITLE
Add ValueGameNode to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ Here are some projects and websites that creatively integrate [no-as-a-service](
 15. **[No MCP](https://github.com/clafoutis42/no-mcp)**  
     Perfect for when you want your AI to be consistently negative or just want to add some humor to your MCP setup.
 
-16. **[Your Project Here?](https://github.com/YOUR_REPO)**
+16. **[ValueGameNode](https://valuegamenode.com)**  
+    Game server hosting and every 404 page hit fetches a fresh `/no` to get a random response.
+
+17. **[Your Project Here?](https://github.com/YOUR_REPO)**
    If you're using no-as-a-service in your project, open a pull request to be featured here!
 
 ---


### PR DESCRIPTION
Adding ValueGameNode game server hosting that uses `/no` on the 404 page. Every missing route gets a fresh random rejection :)
Live: https://valuegamenode.com/nope
